### PR TITLE
README improval and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ In order to install required dependencies, run following command from the projec
 	pip install -r requirements.txt
   
   #### Supported versions:
-  Make sure you have at python2.7 or python3.6 or higher installed.
+  Make sure you have python2.7 or python3.6 or higher installed.
 
 
-### Running the *Better AWS Cli*
+### Running the *Better AWS Cli*  (*BAC*)
 Each AWS account that you wish to manage with the tool must have their respective authentication credentials sourced in the shared AWS *credentials* file (default location of this file is` ~/.aws/credentials`).
 
 If you wish to use the IAM Role assumption to manage the accounts, you must set up your AWS *configuration* file accordingly (this file's default location is `~/.aws/config`).
@@ -32,7 +32,7 @@ The basic intended workflow is as follows:
 
 #### Managing profiles and regions
 
-Several commands have been defined to help manage on which profiles and regions the called aws-cli commands get executed on. To manage profiles, you can use:
+When working with the *BAC*, you can decide on which named profiles and regions the called aws-cli commands get executed. Such profiles and regions are referred to as *active profiles* and *active regions*. Several *BAC*-specific commands have been defined to help manage this. To manage profiles, you can use:
 
  - `include-profiles [profiles]` - includes all provided `profiles` to the set of currently active profiles.
 	
@@ -42,6 +42,10 @@ Several commands have been defined to help manage on which profiles and regions 
  - `list-active-profiles` - lists all currently active profiles.
  
  If `--profile <profile>` is provided to the *aws-cli* command, the set of currently active profiles is disregarded, and the explicitly provided `profile` is used instead.
+
+To include, exclude or switch onto all available profiles, you can use the wildcard (*\**) expression like this:
+
+	~> include-profiles *
 
 The same rules apply to active region management, with one exception: If no region is active (i.e., the set of currently active regions is empty), `--region "us-east-1"`  is used as the default region.
 
@@ -84,3 +88,5 @@ If you do not have *tox* installed, or do not wish to do so, you can tun the tes
 (C) 2020 GoodData Corporation
 
 This project is licensed under the terms of the BSD License 2.0. See [LICENSE](LICENSE.txt).
+
+

--- a/bac/awscli_receiver.py
+++ b/bac/awscli_receiver.py
@@ -154,7 +154,8 @@ class AwsCliReceiver(object):
         try:
             filtered = self._filter(regions, command, profile)
         except ClientError as e:
-            if 'UnauthorizedOperation' in str(e):
+            if ('UnauthorizedOperation' in str(e)
+                or 'AccessDeniedException' in str(e)):
                 log.warning(
                         'Region filtering is not supported for "%s"'
                         ' profile. This is most probably caused by'

--- a/bac/bac_completer.py
+++ b/bac/bac_completer.py
@@ -181,7 +181,7 @@ class BACCompleter(Completer):
                 yield c
             return
 
-        if self._query_context:
+        if self._query_context and '--query' in words:
             quote, start = self._query_context
 
             if (document.cursor_position <= start):
@@ -227,6 +227,9 @@ class BACCompleter(Completer):
                     Document(text[start:]), completion_event):
                 yield c
             return
+
+        elif self._query_context:
+                self._query_context = None
 
         # autocomplete aws-cli commands
         for c in self._aws_completer.get_completions(

--- a/bac/batch.py
+++ b/bac/batch.py
@@ -102,10 +102,9 @@ class CommandBatch(object):
                 log.warning('Command "%s" ended with following non-zero exit'
                             ' code: %s' % (command, exit_code))
                 if err:
-                    err = err.decode('utf-8')
                     log.error('An error occured: "%s"' % text_type(err))
             if out:
-                print(out.decode('utf-8'))
+                print(out)
 
     def _load_batch_command(self, path):
         path = os.path.expanduser(path)

--- a/bac/query_completer.py
+++ b/bac/query_completer.py
@@ -379,10 +379,13 @@ class QueryCompleter(Completer):
             return self.context.keys()
 
     def _handle_others(self, token, _, index):
-        if (token['type'] == 'comma' and
-                self._stack and self._stack[-1][0] == 'lbrace'):
-            self._colon = False
-            return
+        if token['type'] == 'comma':
+            if self._stack and self._stack[-1][0] == 'lbrace':
+                self._colon = False
+                return
+            if not self._stack:
+                self._disable = (True, token['end'])
+                return
 
         # Drop to fallback context on these... (&& || , > < etc...)
         if token['type'] in CONTEXT_RESET_SIGNS:


### PR DESCRIPTION
Adds some more information to the tool's README.md.


**CHANGES:**
- Fixed python 3.6+ _batch-command_ error, where duplicate decoding to utf-8 caused the tool to crash.
- Fixed invalid suggestions after "comma" when not nested (comma doesn't make any sense here and shouldn't suggest anything).
- Fixed bad completer behavior - sometimes the completer would not register the deletion on "--query" argument and would keep suggesting Query completions when it shouldn't.
- Change content of the message logged when "AccessDeniedException" is received while attempting to filter regions.